### PR TITLE
Allow using the websocket preset via a property

### DIFF
--- a/jobs/proxy/spec
+++ b/jobs/proxy/spec
@@ -36,6 +36,6 @@ properties:
     default: "100mb"
     example: "20mb"
   websocket:
-    description: "Enabling forwarding WebSocket connections"
+    description: "Enable forwarding WebSocket connections"
     default: false
     example: true

--- a/jobs/proxy/spec
+++ b/jobs/proxy/spec
@@ -35,3 +35,7 @@ properties:
     description: "Client request size limit"
     default: "100mb"
     example: "20mb"
+  websocket:
+    description: "Enabling forwarding WebSocket connections"
+    default: false
+    example: true

--- a/jobs/proxy/templates/Caddyfile.erb
+++ b/jobs/proxy/templates/Caddyfile.erb
@@ -31,6 +31,7 @@ https://<%= p('hostname') %> {
     header_downstream X-XSS-Protection "1; mode=block"
     header_downstream X-Content-Type-Options "nosniff"
     header_downstream Strict-Transport-Security "max-age=31536000;"
+    <% if p('websocket') %>websocket<% end %>
   }
 
   tls {


### PR DESCRIPTION
We need to be able to use caddy's websocket preset when proxying something which needs to upgrade the connection to a websocket such as with concourse's `fly hijack`.
