### PR TITLE
add support for Caddy's insecure_skip_verify

### DIFF
--- a/jobs/proxy/spec
+++ b/jobs/proxy/spec
@@ -39,6 +39,10 @@ properties:
     description: "Enable forwarding WebSocket connections"
     default: false
     example: true
+  insecure_skip_verify:
+    description: "Overrides verification of the backend TLS certificate"
+    default: false
+    example: true
   headers.referrer_policy:
     description: "Value of Referrer-Policy HTTP header sent to clients"
     default: strict-origin-when-cross-origin

--- a/jobs/proxy/templates/Caddyfile.erb
+++ b/jobs/proxy/templates/Caddyfile.erb
@@ -31,6 +31,7 @@
     header_downstream Strict-Transport-Security "max-age=31536000;"
     header_downstream Referrer-Policy "<%= p('headers.referrer_policy') %>"
     <% if p('websocket') %>websocket<% end %>
+    <% if p('insecure_skip_verify') %>insecure_skip_verify<% end %>
   }
 
   tls {


### PR DESCRIPTION
Sometimes you want to put instant-https in front of an existing https webapp that uses an untrusted or self-signed cert.

https://caddyserver.com/docs/proxy