### PR TITLE
Store caddy's certs and private keys in persistent storage

### DIFF
--- a/jobs/proxy/templates/caddy_ctl.erb
+++ b/jobs/proxy/templates/caddy_ctl.erb
@@ -14,6 +14,10 @@ case $1 in
     mkdir -p "${RUN_DIR}" "${LOG_DIR}"
     chown -R vcap:vcap "${RUN_DIR}" "${LOG_DIR}"
 
+    # Store caddy's certs and private keys in persistent storage
+    export CADDYPATH=/var/vcap/store/proxy/caddy
+    mkdir -p "${CADDYPATH}"
+
     # Let Caddy listen on ports 80 and 443
     setcap cap_net_bind_service=+ep "${CADDY}"
 


### PR DESCRIPTION
Set the [CADDYPATH](https://caddyserver.com/docs/automatic-https#dot-caddy) env var so that certs and private keys are in [persistent storage](https://bosh.io/docs/vm-config.html#storage) to help with issues like #16.

I havent bothered migrating the existing .caddy dir to /var/vcap/store (TIL it's in  /etc/sv/monit/.caddy)

